### PR TITLE
fix: sanitize tunnel name before using as config file path

### DIFF
--- a/managers/install.go
+++ b/managers/install.go
@@ -175,7 +175,7 @@ func InstallTunnel(configJSON string) error {
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
-	configPath := filepath.Join(configDir, name+".json")
+	configPath := filepath.Join(configDir, sanitizeServiceName(name)+".json")
 	if err := os.WriteFile(configPath, []byte(configJSON), 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
@@ -229,7 +229,7 @@ func UninstallTunnel(name string) error {
 
 	// Clean up config file
 	configDir := filepath.Join(os.Getenv("ProgramData"), config.AppName, "Tunnels")
-	configPath := filepath.Join(configDir, name+".json")
+	configPath := filepath.Join(configDir, sanitizeServiceName(name)+".json")
 	os.Remove(configPath) // Best effort cleanup
 
 	return nil


### PR DESCRIPTION
  The tunnel name from user-supplied JSON config was used directly
  in filepath.Join() when writing/removing tunnel config files,
  allowing path traversal attacks (e.g. name: ../../system32/...).

  Apply sanitizeServiceName() to the filename in both InstallTunnel
  and UninstallTunnel, consistent with how the service name is
  already sanitized.

  Fixes a potential arbitrary file write/delete as SYSTEM.

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description


## How to test?


